### PR TITLE
Fix Appveyor upload

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,13 +6,13 @@ environment:
 install:
     - cmd: set QT5_DIR=C:\Qt\5.10.1\msvc2015_64\lib\cmake
     - cmd: choco install OpenCV
-    - cmd: choco install curl
+    - cmd: choco install curl --version=7.65.3
     - cmd: set OPENCV_DIR=C:\tools\opencv\build
     - cmd: cd C:\projects\PixelAnnotationTool
-        
+
 build_script:
     - cmd: mkdir build
     - cmd: cd build
     - cmd: cmake .. -DQT5_DIR=%QT5_DIR% -DOpenCV_DIR=%OPENCV_DIR% -G"Visual Studio 14 Win64"
     - cmd: cmake --build . --config Release
-    - cmd: cmake --build . --config Release --target upload_file    
+    - cmd: cmake --build . --config Release --target upload_file

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ environment:
 
 install:
     - cmd: set QT5_DIR=C:\Qt\5.10.1\msvc2015_64\lib\cmake
-    - cmd: choco install curl --version=7.65.3
     - cmd: choco install OpenCV
+    - cmd: choco install curl --version=7.65.3
     - cmd: set OPENCV_DIR=C:\tools\opencv\build
     - cmd: cd C:\projects\PixelAnnotationTool
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ skip_branch_with_pr: true
 install:
     - cmd: set QT5_DIR=C:\Qt\5.10.1\msvc2015_64\lib\cmake
     - cmd: choco install OpenCV
-    - cmd: choco install curl --version=7.65.3
+    - cmd: choco install curl --version=7.66.0.20190926
     - cmd: set OPENCV_DIR=C:\tools\opencv\build
     - cmd: cd C:\projects\PixelAnnotationTool
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ environment:
     matrix:
         - CMAKE_BUILD_TYPE: Release
 
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
 install:
     - cmd: set QT5_DIR=C:\Qt\5.10.1\msvc2015_64\lib\cmake
     - cmd: choco install OpenCV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ environment:
 
 install:
     - cmd: set QT5_DIR=C:\Qt\5.10.1\msvc2015_64\lib\cmake
-    - cmd: choco install OpenCV
     - cmd: choco install curl --version=7.65.3
+    - cmd: choco install OpenCV
     - cmd: set OPENCV_DIR=C:\tools\opencv\build
     - cmd: cd C:\projects\PixelAnnotationTool
 


### PR DESCRIPTION
There is an issue with the current version of `curl` (7.67.0) (see: https://github.com/curl/curl/issues/4624) which makes the cmake upload step fail.
Downgrading to the version released just before that (7.66.0.20190926) seems to make the build pass for now.
As soon as there is a new version of `curl`, the version specifier in `appveyor.yml` can be removed again.